### PR TITLE
correction stockage des img AI generated

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -104,7 +104,8 @@ def run_generate_img
   image_url = image&.url
 
   if image_url.present?
-    @recipe.update(url_image: image_url)
+    uploaded_image = Cloudinary::Uploader.upload(image_url)
+    @recipe.update(url_image: uploaded_image["secure_url"])
     redirect_to @recipe, notice: "Image generated and recipe updated ✅"
   else
     redirect_to @recipe, alert: "Failed to generate image ❌"


### PR DESCRIPTION
🛠 Fix : Sauvegarde des images générées de manière persistante
Les URL des images générées par DALL·E n’étaient valables que temporairement (quelques heures).
Cette PR ajoute une étape pour uploader ces images sur Cloudinary, et mettre à jour l’attribut url_image de la recette avec l’URL Cloudinary permanente et sécurisée.

✅ Changements principaux :
Upload de l’image générée via Cloudinary::Uploader.upload

Récupération de l’URL (secure_url)

Mise à jour de la recette avec cette URL persistante

